### PR TITLE
Parse meta data

### DIFF
--- a/addon/embed-extractor.js
+++ b/addon/embed-extractor.js
@@ -6,7 +6,10 @@ function EmbedExtractor(raw){
 }
 
 EmbedExtractor.prototype.extractArray = function(){
-  var result = this.extractEmbedded(this.raw);
+  var raw = this.raw;
+
+  var result = this.extractEmbedded(raw);
+
   var extractor = this;
 
   Ember.keys(extractor.sideloads).forEach(function(key){

--- a/tests/unit/models/meta-test.js
+++ b/tests/unit/models/meta-test.js
@@ -1,0 +1,108 @@
+import {
+  test,
+  moduleForModel
+} from "ember-qunit";
+import Pretender from "pretender";
+import Ember from "ember";
+
+var server;
+
+moduleForModel('moose', 'Metadata', {
+  needs: ['serializer:application', 'adapter:application'],
+  teardown: function(){
+    if (server) {
+      server.shutdown();
+      server = null;
+    }
+  }
+});
+
+test('loads meta data from top-level non-reserved keys for collection resources', function(){
+  server = new Pretender(function(){
+    this.get('/mooses', function(){
+      return [200, {}, {
+        page: 1,
+        total_pages: 2,
+        _links: {
+          self: { href: '/mooses' }
+        },
+        _embedded: {
+          mooses: [{
+            id: 'moose-9000',
+            _links: {
+              self: {
+                href: "http://example.com/mooses/moose-9000"
+              }
+            }
+          }]
+        }
+      }];
+    });
+  });
+
+  var store = this.store();
+  return store.find('moose').then(function(mooses){
+    var meta = store.metadataFor('moose');
+
+    deepEqual(meta, {page: 1, total_pages: 2});
+  });
+});
+
+test('loads meta data from explicit `meta` key for collections', function(){
+  server = new Pretender(function(){
+    this.get('/mooses', function(){
+      return [200, {}, {
+        meta: {
+          page: 1,
+          total_pages: 2,
+        },
+        _links: {
+          self: { href: '/mooses' }
+        },
+        _embedded: {
+          mooses: [{
+            id: 'moose-9000',
+            _links: {
+              self: {
+                href: "http://example.com/mooses/moose-9000"
+              }
+            }
+          }]
+        }
+      }];
+    });
+  });
+
+  var store = this.store();
+  return store.find('moose').then(function(mooses){
+    var meta = store.metadataFor('moose');
+
+    deepEqual(meta, {page: 1, total_pages: 2});
+  });
+});
+
+test('loads meta data from explicit `meta` key for single resources', function(){
+  server = new Pretender(function(){
+    this.get('/mooses/1', function(){
+      return [200, {}, {
+        meta: {
+          page: 1,
+          total_pages: 2,
+        },
+        _links: {
+          self: { href: '/mooses/1' }
+        },
+        id: 'moose-9000'
+      }];
+    });
+  });
+
+  var store = this.store();
+  return Ember.run(function(){
+    store.find('moose', 1).then(function(mooses){
+      var meta = store.metadataFor('moose');
+
+      deepEqual(meta, {page: 1, total_pages: 2});
+    });
+  });
+});


### PR DESCRIPTION
For collection resources, pluck top-level keys that are not reserved (reserved: `_links`, `_embedded`, and for backwards compatibility, `_meta`).

For singular resources, only an explicit top-level `meta` key is respected, because it is not feasible to otherwise tell which properties are meta and which belong on the model.