### PR TITLE
Refactor to use `pathForType` and pluralized key names

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -93,14 +93,14 @@ export default DS.ActiveModelSerializer.extend({
   },
 
   extractSingle: function(store, primaryType, rawPayload, recordId) {
-    var extracted = new EmbedExtractor(rawPayload).
+    var extracted = new EmbedExtractor(rawPayload, store).
       extractSingle(primaryType.typeKey);
 
     return this._super(store, primaryType, extracted, recordId);
   },
 
   extractArray: function(store, primaryType, rawPayload) {
-    var extracted = new EmbedExtractor(rawPayload).extractArray();
+    var extracted = new EmbedExtractor(rawPayload, store).extractArray();
 
     return this._super(store, primaryType, extracted);
   },

--- a/tests/dummy/app/models/owner.js
+++ b/tests/dummy/app/models/owner.js
@@ -2,5 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
-  team: DS.belongsTo('team', {async:true})
+  team: DS.belongsTo('team', {async:true}),
+  favoriteCar: DS.belongsTo('car', {async:true})
 });

--- a/tests/unit/extractor-extract-array-test.js
+++ b/tests/unit/extractor-extract-array-test.js
@@ -7,6 +7,18 @@ import EmbedExtractor from "ember-data-hal-9000/embed-extractor";
 
 module('EmbedExtractor - extractArray');
 
+var mockStore = {
+  adapterFor: function(){
+    return mockAdapter;
+  }
+};
+
+var mockAdapter = {
+  pathForType: function(key){
+    return Ember.Inflector.inflector.pluralize(key);
+  }
+};
+
 test('moves array embeds out of _embedded and into top-level', function(){
   var raw = {
     _embedded: {
@@ -17,7 +29,7 @@ test('moves array embeds out of _embedded and into top-level', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractArray();
+  var extracted = new EmbedExtractor(raw, mockStore).extractArray();
 
   deepEqual(extracted, {
     users: [{
@@ -47,7 +59,7 @@ test('deeply embedded', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractArray();
+  var extracted = new EmbedExtractor(raw, mockStore).extractArray();
 
   deepEqual(extracted, {
     users: [{

--- a/tests/unit/extractor-extract-single-test.js
+++ b/tests/unit/extractor-extract-single-test.js
@@ -4,8 +4,20 @@ import {
 import Ember from "ember";
 import EmbedExtractor from "ember-data-hal-9000/embed-extractor";
 
-
 module('EmbedExtractor - extractSingle');
+
+var mockStore = {
+  adapterFor: function(){
+    return mockAdapter;
+  }
+};
+
+var mockAdapter = {
+  pathForType: function(key){
+    return Ember.Inflector.inflector.pluralize(key);
+  }
+};
+
 
 test('it exists', function(){
   ok(EmbedExtractor, 'it exists');
@@ -19,8 +31,8 @@ test('puts simple payload in namespace', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractSingle('user');
-  deepEqual(extracted, {user: raw});
+  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
+  deepEqual(extracted, {users: [raw]});
 });
 
 test('embedded single objects are replaced by ids and sideloaded', function(){
@@ -35,14 +47,14 @@ test('embedded single objects are replaced by ids and sideloaded', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractSingle('user');
+  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
 
   deepEqual(extracted, {
-    user: {
+    users: [{
       id: 1,
       name: 'blah',
       car: 'car-1'
-    },
+    }],
     cars: [{
       id: 'car-1',
       model: 'miata'
@@ -62,14 +74,14 @@ test('embedded arrays of objects are replaced by array of ids and sideloaded', f
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractSingle('user');
+  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
 
   deepEqual(extracted, {
-    user: {
+    users: [{
       id: 1,
       name: 'blah',
       cars: ['car-1']
-    },
+    }],
     cars: [{
       id: 'car-1',
       model: 'miata'
@@ -102,14 +114,14 @@ test('deeply embedded objects and arrays are replaced by array/single ids and si
     }
   };
 
-  var extracted = new EmbedExtractor(raw).extractSingle('user');
+  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
 
   deepEqual(extracted, {
-    user: {
+    users: [{
       id: 1,
       name: 'blah',
       cars: ['car-1']
-    },
+    }],
     drivers: [{
       id: 'd1',
       name: 'driver 1',

--- a/tests/unit/models/meta-test.js
+++ b/tests/unit/models/meta-test.js
@@ -109,7 +109,7 @@ test('includes links in meta data for collections', function(){
 
 test('loads meta data from explicit `meta` key for single resources', function(){
   server = new Pretender(function(){
-    this.get('/mooses/1', function(){
+    this.get('/mooses/moose-9000', function(){
       return [200, {}, {
         meta: {
           page: 1,
@@ -125,7 +125,7 @@ test('loads meta data from explicit `meta` key for single resources', function()
 
   var store = this.store();
   return Ember.run(function(){
-    store.find('moose', 1).then(function(mooses){
+    store.find('moose', 'moose-9000').then(function(mooses){
       var meta = store.metadataFor('moose');
 
       deepEqual(meta, {page: 1, total_pages: 2});


### PR DESCRIPTION
Ember Data wants responses (even to a singular resource request) to
have pluralized property names in the JSON payload, e.g. find('user', 1)
should end up with a json payload like:
```
{
  users: [{
    id: 1,
    ...
  }]
}
```