### PR TITLE
Use the store, primaryType and serializer when serializing.

### DIFF
--- a/addon/embed-extractor.js
+++ b/addon/embed-extractor.js
@@ -86,7 +86,8 @@ EmbedExtractor.prototype.extractEmbedded = function(hash, primaryType, primarySe
 
     } else {
       value = extractor.extractEmbedded(value, type, typeSerializer);
-      id = value.id; // TODO ember data provides a way of overriding the id property, right?
+      // TODO use the serializer's 'primaryKey' property instead
+      id = value.id;
       result[key] = id;
 
       extractor.addValueOfType(value, type);

--- a/addon/embed-extractor.js
+++ b/addon/embed-extractor.js
@@ -1,34 +1,37 @@
 import Ember from "ember";
 
-function EmbedExtractor(raw, store){
+function EmbedExtractor(raw, store, primarySerializer){
   this.raw = raw;
   this.store = store;
   this.result = {};
+  this.serializer = primarySerializer;
 }
 
-EmbedExtractor.prototype.extractArray = function(){
-  this.extractEmbedded(this.raw);
+EmbedExtractor.prototype.extractArray = function(primaryType){
+  this.extractEmbedded(this.raw, primaryType, this.serializer);
 
   return this.result;
 };
 
-EmbedExtractor.prototype.extractSingle = function(typeKey){
-  var value = this.extractEmbedded(this.raw);
-  this.addValueOfType(value, typeKey); // TODO This can put the primary object last in the sideload result set
+// type is a DS.Model
+EmbedExtractor.prototype.extractSingle = function(type){
+  var value = this.extractEmbedded(this.raw, type, this.serializer);
+  this.addValueOfType(value, type); // TODO This can put the primary object last in the sideload result set, that might be bad
 
   return this.result;
 };
 
-EmbedExtractor.prototype.adapterFor = function(type){
-  return this.store.adapterFor(type);
+EmbedExtractor.prototype.pathForType = function(type){
+  var model = this.modelFor(type);
+  return this.store.adapterFor(model).pathForType(model.typeKey);
 };
 
 // Add a value of the given type to the result set.
 // This is called when `extractEmbedded` comes across an embedded object
 // that should be sideloaded, and when `extractSingle` wants to add its
 // primary type to a top-level array.
-EmbedExtractor.prototype.addValueOfType = function(value, typeKey) {
-  var pathForType = this.store.adapterFor(typeKey).pathForType(typeKey);
+EmbedExtractor.prototype.addValueOfType = function(value, type) {
+  var pathForType = this.store.adapterFor(type).pathForType(type.typeKey);
 
   if (!this.result[pathForType]) {
     this.result[pathForType] = [];
@@ -45,37 +48,48 @@ EmbedExtractor.prototype.addValueOfType = function(value, typeKey) {
 // extractEmbedded will addValueOfType with the pet, and set hash.pet = 1;
 //
 // Returns the modified hash
-EmbedExtractor.prototype.extractEmbedded = function(hash){
+EmbedExtractor.prototype.extractEmbedded = function(hash, primaryType, primarySerializer){
   var extractor = this;
   var result   = hash;
   var embedded = hash._embedded || {};
   delete result._embedded;
 
-  Ember.keys(embedded).forEach(function(key){
-    var value = embedded[key];
+  var value, id;
+
+  for (var key in embedded) {
+    var typeKey = primarySerializer.typeForRoot(key);
+    if (!this.store.modelFactoryFor(typeKey)) {
+      Ember.warn("Skipping unknown type: " + key);
+      continue;
+    }
+    var type           = this.store.modelFor(typeKey);
+    var typeSerializer = this.store.serializerFor(type);
+
+    value = embedded[key];
 
     if (Ember.isArray(value)) {
       var embeddedIds = [];
 
-      value.forEach(function(embeddedObject){
-        var extracted = extractor.extractEmbedded(embeddedObject);
-        var id = extracted.id;
+      for (var i=0, len=value.length; i < len; i++) {
+        var embeddedObject = value[i];
+        var extracted = extractor.extractEmbedded(embeddedObject, type, typeSerializer);
+        id = extracted.id;
         embeddedIds.push(id);
 
-        extractor.addValueOfType(extracted, key);
-      });
+        extractor.addValueOfType(extracted, type);
+      }
 
       // TODO should be `keyForRelationship` (to determine if it should be, e.g., "modelName_ids")
       result[key] = embeddedIds;
 
     } else {
-      value = extractor.extractEmbedded(value);
-      var id = value.id;
+      value = extractor.extractEmbedded(value, type, typeSerializer);
+      id = value.id; // TODO ember data provides a way of overriding the id property, right?
       result[key] = id;
 
-      extractor.addValueOfType(value, key);
+      extractor.addValueOfType(value, type);
     }
-  });
+  }
 
   return result;
 };

--- a/addon/embed-extractor.js
+++ b/addon/embed-extractor.js
@@ -8,6 +8,9 @@ function EmbedExtractor(raw, store, primarySerializer){
 }
 
 EmbedExtractor.prototype.extractArray = function(primaryType){
+  // initialize result set with primary type
+  this.result[ this.pathForType(primaryType) ] = [];
+
   this.extractEmbedded(this.raw, primaryType, this.serializer);
 
   return this.result;
@@ -22,8 +25,7 @@ EmbedExtractor.prototype.extractSingle = function(type){
 };
 
 EmbedExtractor.prototype.pathForType = function(type){
-  var model = this.modelFor(type);
-  return this.store.adapterFor(model).pathForType(model.typeKey);
+  return this.store.adapterFor(type).pathForType(type.typeKey);
 };
 
 // Add a value of the given type to the result set.

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -33,13 +33,6 @@ function setMeta(store, type, meta){
 }
 
 export default DS.ActiveModelSerializer.extend({
-  serializeIntoHash: function(hash, type, record, options){
-    var serialized = this.serialize(record, options);
-    Ember.keys(serialized).forEach(function(key){
-      hash[key] = serialized[key];
-    });
-  },
-
   /*
    `__requestType` is used to know if we are
    dealing with a list resource (i.e., GET /users) which may

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -92,15 +92,34 @@ export default DS.ActiveModelSerializer.extend({
     return this._super(store, type, payload, id, requestType);
   },
 
+  /**
+   * https://github.com/emberjs/data/blob/48c02654e8a524b390d1a28975416ee73f912d9e/packages/ember-data/lib/serializers/rest_serializer.js#L263
+    @method extractSingle
+    @param {DS.Store} store
+    @param {subclass of DS.Model} primaryType
+    @param {Object} payload
+    @param {String} recordId
+    @return {Object} the primary response to the original request
+   */
   extractSingle: function(store, primaryType, rawPayload, recordId) {
-    var extracted = new EmbedExtractor(rawPayload, store).
-      extractSingle(primaryType.typeKey);
+    var extracted = new EmbedExtractor(rawPayload, store, this).
+      extractSingle(primaryType);
 
     return this._super(store, primaryType, extracted, recordId);
   },
 
+  /*
+   * https://github.com/emberjs/data/blob/48c02654e8a524b390d1a28975416ee73f912d9e/packages/ember-data/lib/serializers/rest_serializer.js#L417
+    @method extractArray
+    @param {DS.Store} store
+    @param {subclass of DS.Model} primaryType
+    @param {Object} payload
+    @return {Array} The primary array that was returned in response
+      to the original query.
+  */
   extractArray: function(store, primaryType, rawPayload) {
-    var extracted = new EmbedExtractor(rawPayload, store).extractArray();
+    var extracted = new EmbedExtractor(rawPayload, store, this).
+      extractArray(primaryType);
 
     return this._super(store, primaryType, extracted);
   },

--- a/tests/unit/extractor-extract-array-test.js
+++ b/tests/unit/extractor-extract-array-test.js
@@ -10,12 +10,30 @@ module('EmbedExtractor - extractArray');
 var mockStore = {
   adapterFor: function(){
     return mockAdapter;
+  },
+
+  modelFor: function(typeKey){
+    return {typeKey:typeKey};
+  },
+
+  modelFactoryFor: function(){
+    return true;
+  },
+
+  serializerFor: function(){
+    return mockSerializer;
   }
 };
 
 var mockAdapter = {
-  pathForType: function(key){
-    return Ember.Inflector.inflector.pluralize(key);
+  pathForType: function(typeKey){
+    return Ember.Inflector.inflector.pluralize(typeKey);
+  }
+};
+
+var mockSerializer = {
+  typeForRoot: function(typeKey){
+    return Ember.Inflector.inflector.singularize(typeKey);
   }
 };
 
@@ -29,7 +47,10 @@ test('moves array embeds out of _embedded and into top-level', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractArray();
+  var mockType = {typeKey: 'user'};
+
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractArray(mockType);
 
   deepEqual(extracted, {
     users: [{
@@ -59,7 +80,9 @@ test('deeply embedded', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractArray();
+  var mockType = {typeKey: 'user'};
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractArray(mockType);
 
   deepEqual(extracted, {
     users: [{

--- a/tests/unit/extractor-extract-single-test.js
+++ b/tests/unit/extractor-extract-single-test.js
@@ -9,12 +9,30 @@ module('EmbedExtractor - extractSingle');
 var mockStore = {
   adapterFor: function(){
     return mockAdapter;
+  },
+
+  modelFor: function(typeKey){
+    return {typeKey:typeKey};
+  },
+
+  modelFactoryFor: function(){
+    return true;
+  },
+
+  serializerFor: function(){
+    return mockSerializer;
   }
 };
 
 var mockAdapter = {
-  pathForType: function(key){
-    return Ember.Inflector.inflector.pluralize(key);
+  pathForType: function(typeKey){
+    return Ember.Inflector.inflector.pluralize(typeKey);
+  }
+};
+
+var mockSerializer = {
+  typeForRoot: function(typeKey){
+    return Ember.Inflector.inflector.singularize(typeKey);
   }
 };
 
@@ -31,7 +49,9 @@ test('puts simple payload in namespace', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
+  var mockType = {typeKey: 'user'};
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractSingle(mockType);
   deepEqual(extracted, {users: [raw]});
 });
 
@@ -47,7 +67,9 @@ test('embedded single objects are replaced by ids and sideloaded', function(){
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
+  var mockType = {typeKey: 'user'};
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractSingle(mockType);
 
   deepEqual(extracted, {
     users: [{
@@ -74,7 +96,9 @@ test('embedded arrays of objects are replaced by array of ids and sideloaded', f
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
+  var mockType = {typeKey: 'user'};
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractSingle(mockType);
 
   deepEqual(extracted, {
     users: [{
@@ -114,7 +138,9 @@ test('deeply embedded objects and arrays are replaced by array/single ids and si
     }
   };
 
-  var extracted = new EmbedExtractor(raw, mockStore).extractSingle('user');
+  var mockType = {typeKey: 'user'};
+  var extracted = new EmbedExtractor(raw, mockStore, mockSerializer).
+    extractSingle(mockType);
 
   deepEqual(extracted, {
     users: [{

--- a/tests/unit/models/moose-test.js
+++ b/tests/unit/models/moose-test.js
@@ -102,36 +102,3 @@ test('loads single HAL formatted record', function(){
     });
   });
 });
-
-test('can create a new record', function(){
-  expect(4);
-
-  server = new Pretender(function(){
-    this.post('/mooses', function(request){
-      var json = JSON.parse(request.requestBody);
-      deepEqual(json, {name: 'Marcy'}, 'POSTs correct JSON');
-      return [200, {}, {
-        _links: {
-          self: {
-            href: "http://example.com/mooses/moose-9000"
-          }
-        },
-        id: 'moose-9000',
-        name: 'Marcy'
-      }];
-    });
-  });
-
-  var store = this.store();
-
-  return Ember.run(function(){
-    var mooseData = {name: 'Marcy'};
-    var moose = store.createRecord('moose', mooseData);
-
-    return moose.save().then(function(moose){
-      ok(moose, 'record created');
-      ok(moose.get('id'), 'moose-9000', 'record loaded');
-      ok(moose.get('name'), 'Marcy', 'record has an attribute');
-    });
-  });
-});


### PR DESCRIPTION
Allows us to use typeForRoot and pathForType properly when restructuring.