### PR TITLE
Ember data 1 13 support

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -1,4 +1,4 @@
 import DS from "ember-data";
 
-export default DS.RESTAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
 });

--- a/addon/resource.js
+++ b/addon/resource.js
@@ -5,9 +5,10 @@ function isEmptyObject(object) {
 }
 
 export default class Resource {
-  constructor({id, type, attributes}) {
+  constructor({id, key, type, attributes}) {
     this.id = id;
     this.type = type;
+    this.key = key;
     this.attributes = attributes;
     this.relationships = {};
   }
@@ -21,10 +22,9 @@ export default class Resource {
    *   or an array of resource identifier objects
    */
   pushRelationship(relationshipResource, isCollection=false) {
-    const type = relationshipResource.type;
-
-    if (!this.relationships[type]) {
-      this.relationships[type] = {
+    const key = relationshipResource.key;
+    if (!this.relationships[key]) {
+      this.relationships[key] = {
         // FIXME optionally add links and meta
         data: null
       };
@@ -32,18 +32,18 @@ export default class Resource {
 
     const resourceIdentifier = relationshipResource.toIdentifier();
     if (isCollection) {
-      if (!this.relationships[type].data) { this.relationships[type].data = []; }
+      if (!this.relationships[key].data) { this.relationships[key].data = []; }
       Ember.assert('Cannot push relationship as a collection unless `data` is an array',
-                   Array.isArray(this.relationships[type].data));
-      this.relationships[type].data.push(resourceIdentifier);
+                   Array.isArray(this.relationships[key].data));
+      this.relationships[key].data.push(resourceIdentifier);
     } else {
-      if (!this.relationships[type].data) { this.relationships[type].data = {}; }
+      if (!this.relationships[key].data) { this.relationships[key].data = {}; }
       Ember.assert('Cannot push relationship as singular when  `data` is an array',
-                   !Array.isArray(this.relationships[type].data));
-      Ember.assert(`Cannot overwrite pushed singular relationship of type ${type}`,
-                   isEmptyObject(this.relationships[type].data));
+                   !Array.isArray(this.relationships[key].data));
+      Ember.assert(`Cannot overwrite pushed singular relationship of key ${key}`,
+                   isEmptyObject(this.relationships[key].data));
 
-      this.relationships[type].data = resourceIdentifier;
+      this.relationships[key].data = resourceIdentifier;
     }
   }
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,6 +1,7 @@
 import DS from "ember-data";
 import Ember from 'ember';
 import EmbedExtractor from "./embed-extractor";
+import Normalizer from "./normalizer";
 
 // requestType values that indicate that we are loading a collection, not
 // a single resource
@@ -82,12 +83,15 @@ export default DS.JSONAPISerializer.extend({
   normalizeResponse: function(store, type, payload, id, requestType) {
     this.__requestType = requestType; // used by `extractMeta`
 
-    return this._super(store, type, payload, id, requestType);
-  },
+    var normalizer = new Normalizer(store, type, payload, id, requestType);
+    var newPayload;
+    if(payload.id) {
+      newPayload = normalizer.normalizeSingleResponse();
+    } else {
+      newPayload = normalizer.normalizeArrayResponse();
+    }
 
-  normalizeFindAllResponse: function(store, primaryModelClass, payload, id, requestType) {
-    var extracted = new EmbedExtractor(payload, store, this).
-      extractArray(primaryType);
+    return this._super(store, type, newPayload, id, requestType);
   },
 
   /**

--- a/tests/unit/normalizer-collection-test.js
+++ b/tests/unit/normalizer-collection-test.js
@@ -107,6 +107,14 @@ test('#normalizeArrayResponse returns JSON API with nested embeds', function(ass
       key = 'friends';
       kind = 'hasMany';
       callback(key, {kind});
+    },
+
+    relationshipsByName: {
+      get: function(key) {
+        return {
+          type: key
+        };
+      }
     }
   };
   var id, requestType;

--- a/tests/unit/normalizer-singular-test.js
+++ b/tests/unit/normalizer-singular-test.js
@@ -15,7 +15,10 @@ var mockStore = {
   modelFor: function(typeKey){
     return {
       modelName: typeKey,
-      eachRelationship: Ember.K
+      eachRelationship: Ember.K,
+      relationshipsByName: {
+        get: Ember.K
+      }
     };
   },
 
@@ -42,7 +45,10 @@ var mockSerializer = {
 
 var mockUserType = {
   modelName: 'user',
-  eachRelationship: Ember.K
+  eachRelationship: Ember.K,
+  relationshipsByName: {
+    get: Ember.K
+  }
 };
 
 
@@ -226,7 +232,7 @@ test('deeply embedded objects and arrays are replaced by array/single ids and si
         name: 'driver 1'
       },
       relationships: {
-        favoriteColors: {
+        'favorite-colors': {
           data: [{
             id: 'c1', type: 'favoriteColors'
           }, {


### PR DESCRIPTION
@bantic  Making some progress here. Test failures are down from 19 -> 7. This change has 2 commits, the first is to use the `Normalizer` in the `Serializer`. The 2nd is to find the type by looking at the relationships on the model. so for example if you have a User model with `favoriteTeam: DS.belongsTo('team')`, in the HAL JSON we will receive something like `favorite_team: {id: '1'}`, we have to know that this is of type `team` and not of type `favorite_team`.

There are still some failures related to following hrefs and meta data but I'd like to get your feedback before continuing with those.

Thanks
