### PR TITLE
adds extracting jsonapi link objects to meta

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -34,6 +34,24 @@ function coerceId(id) {
   return id == null || id === '' ? null : id + '';
 }
 
+function halToJSONAPILink(link) {
+  let converted,
+    linkKeys = keys(link);
+
+  if (linkKeys.length === 1) {
+    converted = link.href;
+  } else {
+    converted = {href: link.href, meta: {}};
+    linkKeys.forEach(key => {
+      if (key !== 'href') {
+        converted.meta[key] = link[key];
+      }
+    });
+  }
+
+  return converted;
+}
+
 function arrayFlatten(array) {
   let flattened = [];
   return flattened.concat.apply(flattened, array);
@@ -46,7 +64,7 @@ function extractLinksIntoMeta(payload, meta) {
     meta.links = {};
 
     keys(links).forEach(function (key) {
-      meta.links[key] = links[key].href;
+      meta.links[key] = halToJSONAPILink(links[key]);
     });
   }
 
@@ -179,7 +197,7 @@ export default JSONAPISerializer.extend({
     if (payload._links) {
       attributes.links = {};
       Object.keys(payload._links).forEach(link => {
-        attributes.links[link] = this.extractLink(payload._links[link]);
+        attributes.links[link] = halToJSONAPILink(payload._links[link]);
       });
     }
 

--- a/tests/unit/models/has-many-test.js
+++ b/tests/unit/models/has-many-test.js
@@ -64,3 +64,55 @@ test('car#hasMany wheels loads wheels from link', function(assert){
   });
 });
 
+
+test('car#hasMany wheels loads wheels from link without breaking because of hal link object', function(assert){
+  const store = this.store();
+
+  stubRequest('get', '/cars/1', (request) => {
+    request.ok({
+      id: '1',
+      make: 'Miata',
+      model: 'Pretender',
+      _links: {
+        self: { href: '/cars/1' },
+        wheels: {
+          href: '/cars/1/wheels',
+          name: 'Car wheels'
+        }
+      }
+    });
+  });
+
+  stubRequest('get', '/cars/1/wheels', (request) => {
+    request.ok({
+      _links: {
+        self: {
+          href: '/cars/1/wheels',
+          name: 'Car wheels'
+        }
+      },
+      _embedded: {
+        wheels: [{
+          id: 'wheel-1',
+          hasSnowChains: true
+        }, {
+          id: 'wheel-2',
+          hasSnowChains: false
+        }]
+      }
+    });
+  });
+
+  return Ember.run(function(){
+    return store.findRecord('car', 1).then(function(car){
+      return car.get('wheels');
+    }).then(function(wheels){
+      assert.ok(!!wheels, 'gets wheels');
+      assert.equal(wheels.get('length'), 2, 'has 2 wheels');
+
+      var wheel = wheels.get('firstObject');
+      assert.ok(wheel.get('hasSnowChains'), 'wheel has snow chains');
+    });
+  });
+});
+

--- a/tests/unit/models/links-test.js
+++ b/tests/unit/models/links-test.js
@@ -29,3 +29,29 @@ test('single resource links are available in model data.links property', functio
     });
   });
 });
+
+test('single resource link objects are available in model data.links property', function(assert){
+  stubRequest('get', '/mooses/1', (request) => {
+    request.ok({
+      id: 1,
+      _links: {
+        self:  { href: '/mooses/1' },
+        cats:  { href: '/mooses/1/cats{?friendly}', templated: true }
+      }
+    });
+  });
+
+  const store = this.store();
+  return Ember.run(function(){
+    return store.findRecord('moose', 1).then(function(moose){
+      var links = moose.get('data.links');
+
+      assert.deepEqual(links, {
+        self: '/mooses/1',
+        cats: {
+          href: '/mooses/1/cats{?friendly}',
+          meta: {templated: true}
+        }});
+    });
+  });
+});


### PR DESCRIPTION
Extracting hal link objects https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5 into jsonapi link objects http://jsonapi.org/format/#document-links allows us to keep hal metadata while still following the jsonapi spec.
(except the part that ember-data currently doesn't understands https://github.com/emberjs/data/issues/3588)