### PR TITLE
fixes query collection result not containing root level payload meta

### DIFF
--- a/tests/unit/models/meta-test.js
+++ b/tests/unit/models/meta-test.js
@@ -37,6 +37,30 @@ test('loads meta data from top-level non-reserved keys for collection resources'
   });
 });
 
+test('loads meta data from top-level non-reserved keys for collection resources returned from store.query', function(assert){
+  stubRequest('get', '/mooses', (request) => {
+    request.ok({
+      page: 1,
+      total_pages: 2,
+      _embedded: {
+        mooses: [{
+          id: 'moose-9000',
+          _links: {
+            self: {
+              href: "http://example.com/mooses/moose-9000"
+            }
+          }
+        }]
+      }
+    });
+  });
+
+  const store = this.store();
+  return store.query('moose', {}).then(function(mooses){
+    assert.deepEqual(getMetadata(store, 'moose'), {page: 1, total_pages: 2});
+  });
+});
+
 test('loads meta data from explicit `meta` key for collections', function(assert){
   stubRequest('get', '/mooses', (request) => {
     request.ok({


### PR DESCRIPTION
This fixes extracting meta from `store.query` array results.
It simply removes the check for `requestType` being in `"findMany", "findAll", "findHasMany", "findQuery"` and using the existing `isSingle` flag.

It also adds a tests that fails in current master but works in after this commit.