### PR TITLE
removes attributes extraction `attributes` name assertion #30

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -177,9 +177,6 @@ export default JSONAPISerializer.extend({
     let payloadKey,
       attributes = {};
 
-    Ember.assert('Payload can\'t contain attributes key',
-      !payload.hasOwnProperty('attributes'));
-
     primaryModelClass.eachAttribute((attributeName, attributeMeta)=> {
       payloadKey = this.keyForAttribute(attributeName, attributeMeta);
 

--- a/tests/dummy/app/models/attribute.js
+++ b/tests/dummy/app/models/attribute.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  attributes: DS.attr('number')
+});

--- a/tests/dummy/app/models/car.js
+++ b/tests/dummy/app/models/car.js
@@ -3,6 +3,8 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   make:   DS.attr('string'),
   model:  DS.attr('string'),
+
   wheels: DS.hasMany('wheel', {async:true}),
-  owner: DS.belongsTo('owner', {async:true})
+  owner: DS.belongsTo('owner', {async:true}),
+  attributes: DS.hasMany('attribute', {async:true})
 });

--- a/tests/unit/models/attributes-test.js
+++ b/tests/unit/models/attributes-test.js
@@ -1,0 +1,49 @@
+import {
+  test,
+  moduleForModel
+} from "ember-qunit";
+import { stubRequest } from 'ember-cli-fake-server';
+import Ember from "ember";
+
+moduleForModel('car', 'Attributes', {
+  needs: ['serializer:application', 'adapter:application', 'transform:temperature',
+  'model:attribute']
+});
+
+test('allows `attributes` attributes and relations', function(assert){
+  assert.expect(1);
+
+  stubRequest('get', '/cars/1', (request) => {
+    request.ok({
+      id: 1,
+      make: 'foo',
+      model: 'bar',
+
+      _links: {
+        self: { href: '/cars/1' },
+        attributes: {href: '/cars/1/attributes'}
+      }
+    });
+  });
+
+  stubRequest('get', '/cars/1/attributes', (request) => {
+    request.ok({
+      _links: {self: {href: '/cars/1/attributes'}},
+      _embedded: {
+        attributes: [{
+          id: 'some-attribute',
+          attributes: 2
+        }]
+      }
+    });
+  });
+
+  const store = this.store();
+  return Ember.run(function(){
+    return store.findRecord('car', 1).then(function(car){
+      return car.get('attributes').then(attributes => {
+        assert.equal(attributes.get('firstObject.attributes'), 2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
https://github.com/201-created/ember-data-hal-9000/issues/30 removes the `attributes` attributes assertion and adds tests for `attributes` relations and `attributes` attributes.