### PR TITLE
Don't feed embedded records to the Primary Array

### DIFF
--- a/addon/embed-extractor.js
+++ b/addon/embed-extractor.js
@@ -10,18 +10,21 @@ function EmbedExtractor(raw, store, primarySerializer){
 }
 
 EmbedExtractor.prototype.extractArray = function(primaryType){
+  let primaryTypePath = this.pathForType(primaryType);
   // initialize result set with primary type
-  this.result[ this.pathForType(primaryType) ] = [];
+  this.result[primaryTypePath] = [];
 
-  this.extractEmbedded(this.raw, primaryType, this.serializer);
+  this.extractEmbedded(this.raw, primaryType, this.serializer, {
+    primaryTypePath: primaryTypePath
+  });
 
   return this.result;
 };
 
-// type is a DS.Model
-EmbedExtractor.prototype.extractSingle = function(type){
-  var value = this.extractEmbedded(this.raw, type, this.serializer);
-  this.addValueOfType(value, type); // TODO This can put the primary object last in the sideload result set, that might be bad
+// primaryType is a DS.Model
+EmbedExtractor.prototype.extractSingle = function(primaryType){
+  var value = this.extractEmbedded(this.raw, primaryType, this.serializer, {});
+  this.addValueOfType(value, primaryType, {}); // TODO This can put the primary object last in the sideload result set, that might be bad
 
   return this.result;
 };
@@ -35,9 +38,17 @@ EmbedExtractor.prototype.pathForType = function(type){
 // This is called when `extractEmbedded` comes across an embedded object
 // that should be sideloaded, and when `extractSingle` wants to add its
 // primary type to a top-level array.
-EmbedExtractor.prototype.addValueOfType = function(value, type) {
+// This ensures that sideloaded objects don't end up in the primary array by
+// prefixing them with _ as per the spec:
+// https://github.com/emberjs/data/blob/48c02654e8a524b390d1a28975416ee73f912d9e/packages/ember-data/lib/serializers/rest_serializer.js#L401-L408
+EmbedExtractor.prototype.addValueOfType = function(value, type, opts) {
+
   const modelName = getModelName(type);
   var pathForType = this.store.adapterFor(modelName).pathForType(modelName);
+
+  if (opts.forcePrimaryTypeSideload && pathForType === opts.primaryTypePath) {
+    pathForType = '_'.concat(pathForType);
+  }
 
   if (!this.result[pathForType]) {
     this.result[pathForType] = [];
@@ -54,44 +65,55 @@ EmbedExtractor.prototype.addValueOfType = function(value, type) {
 // extractEmbedded will addValueOfType with the pet, and set hash.pet = 1;
 //
 // Returns the modified hash
-EmbedExtractor.prototype.extractEmbedded = function(hash, primaryType, primarySerializer){
+EmbedExtractor.prototype.extractEmbedded = function(hash, containingType, containingTypeSerializer, opts){
   var extractor = this;
   var result   = hash;
   var embedded = hash._embedded || {};
   delete result._embedded;
 
-  var value, id, type, modelName, propName;
+  var value, id, embeddedType, modelName, propName;
 
   for (var key in embedded) {
-    type = null;
+    embeddedType = null;
     modelName = null;
     propName = key;
 
+    // Look for matching type here
 
-    modelName = modelNameFromPayloadKey(primarySerializer, key);
+    modelName = modelNameFromPayloadKey(containingTypeSerializer, key);
 
     /*jshint loopfunc:true*/
-    primaryType.eachRelationship(function(name, relationship){
-      var relationshipModelName = modelNameFromPayloadKey(primarySerializer, name);
+    containingType.eachRelationship(function(name, relationship){
+      var relationshipModelName = modelNameFromPayloadKey(containingTypeSerializer, name);
       if (relationshipModelName === modelName) {
-        type = relationship.type;
+        embeddedType = relationship.type;
         propName = relationship.key;
       }
     });
 
-    if (!type) {
+
+    if (!embeddedType) {
       if (!this.store.modelFactoryFor(modelName)) {
-        Ember.warn("Skipping unknown type: " + key);
+        Ember.warn("Skipping unknown embeddedType: " + key);
         continue;
       }
-      type = this.store.modelFor(modelName);
+      embeddedType = this.store.modelFor(modelName);
     }
 
-    if (typeof type === 'string') {
-      type = this.store.modelFor(type);
+    if (typeof embeddedType === 'string') {
+      embeddedType = this.store.modelFor(embeddedType);
     }
 
-    var typeSerializer = this.store.serializerFor(modelName);
+    var embeddedTypeSerializer = this.store.serializerFor(modelName);
+
+    var recurseAndSideload = function (o) {
+      // When recursing, ensure that anything embedded we find is proprerly interpreted
+      // as a sideload.
+      return extractor.extractEmbedded(o, embeddedType, embeddedTypeSerializer, {
+          primaryTypePath: opts.primaryTypePath,
+          forcePrimaryTypeSideload: true
+        });
+    };
 
     value = embedded[key];
 
@@ -99,24 +121,23 @@ EmbedExtractor.prototype.extractEmbedded = function(hash, primaryType, primarySe
       var embeddedIds = [];
 
       for (var i=0, len=value.length; i < len; i++) {
-        var embeddedObject = value[i];
-        var extracted = extractor.extractEmbedded(embeddedObject, type, typeSerializer);
+        var extracted = recurseAndSideload(value[i]);
         id = extracted.id;
         embeddedIds.push(id);
 
-        extractor.addValueOfType(extracted, type);
+        extractor.addValueOfType(extracted, embeddedType, opts);
       }
 
       // TODO should be `keyForRelationship` (to determine if it should be, e.g., "modelName_ids")
       result[propName] = embeddedIds;
 
     } else {
-      value = extractor.extractEmbedded(value, type, typeSerializer);
+      value = recurseAndSideload(value);
       // TODO use the serializer's 'primaryKey' property instead
       id = value.id;
       result[propName] = id;
 
-      extractor.addValueOfType(value, type);
+      extractor.addValueOfType(value, embeddedType, opts);
     }
   }
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "pretender": "0.3.1"


### PR DESCRIPTION
Hi there,

First a couple notes:

- This patch is for v0.2.x, but I haven't found a branch for it, so I'm sending against master, which may not be the right place to merge it.
- ~~I haven't been able to run tests locally (they just hang forever), but I'm happy to try and add some if you can let me know how!~~

Now, the commit message explains the problem this is solving, and the solution:

Reference: https://github.com/emberjs/data/blob/48c02654e8a524b390d1a28975416ee73f912d9e/packages/ember-data/lib/serializers/rest_serializer.js#L401-L408

extractArray, when responding to findQuery or findMany must ensure that
sideloaded records aren't returned in the primary array. Otherwise, the
sideloaded records will be interpreted as results of the query.

This ends up being a serious problem with reflexive relationships.

For example, assume the following API, which models database replication

    GET /databases/10
    {
      "id": 10,
      "handle": "redis-master",
      "type": "redis",
      "_links": {
        "self": { "href": "/databases/10" },
        "dependents": { "href": "/databases/10/dependents" }
      }
    }

    GET /databases/11
    {
      "id": 11,
      "handle": "redis-replica",
      "type": "redis",
      "_embedded": {
        "initialize_from": {
          << RECORD 10 EMBEDDED HERE >>
        }
      },
      "_links": {
        "self": { "href": "/databases/11" }
      }
    }

    GET /databases/10/dependents
    {
      "_embedded": {
        "dependents": [
          << RECORD 11 EMBEDDED HERE >>
        ]
      }
    }

Wht the current behavior, when you query `/databases/10/dependents`,
then database 11 is embedded, and so is database 10. Since those
are all database records, they will all be returned in the "databases"
field of the result.

Since that's the primary array, those records will be interpreted as
dependents of database 10, and database 10 ends up being a dependent of
itself.

The Ember code suggests that "databases" should be prefixed with "_" in
this case, to ensure that sideloads are properly interpreted as
sideloads, and not as members of the primary array.