### PR TITLE
Fix Issue #52 By Renaming extractMeta

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -82,7 +82,7 @@ export default Ember.Mixin.create({
     return coerceId(id);
   },
 
-  extractMeta (store, requestType, payload, primaryModelClass) {
+  retrieveMetadata (store, requestType, payload, primaryModelClass) {
     const meta = payload.meta || {},
       isSingle = this.isSinglePayload(payload, requestType);
 

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -107,7 +107,7 @@ export default Ember.Mixin.create({
   normalizeResponse (store, primaryModelClass, payload, id, requestType) {
     const isSingle = this.isSinglePayload(payload, requestType),
       documentHash = {},
-      meta = this.extractMeta(store, requestType, payload, primaryModelClass),
+      meta = this.retrieveMetadata(store, requestType, payload, primaryModelClass),
       included = [];
 
     if (meta) {


### PR DESCRIPTION
Fixed: Ember data emitting warning because of 'extractMeta' function #52
https://github.com/201-created/ember-data-hal-9000/issues/52