### PR TITLE
Ensure overriden methods can call `super` correctly

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -222,16 +222,13 @@ export default Ember.Mixin.create({
   extractRelationships(primaryModelClass, payload, included) {
     let relationships = {},
       embedded = payload._embedded,
-      keyForRelationship = this.keyForRelationship,
-      keyForLink = this.keyForLink,
-      extractLink = this.extractLink,
       links = payload._links;
 
     if (embedded || links) {
       primaryModelClass.eachRelationship((key, relationshipMeta) => {
         let relationship,
-          relationshipKey = keyForRelationship(key, relationshipMeta),
-          linkKey = keyForLink(key, relationshipMeta);
+          relationshipKey = this.keyForRelationship(key, relationshipMeta),
+          linkKey = this.keyForLink(key, relationshipMeta);
 
         if (embedded && embedded.hasOwnProperty(relationshipKey)) {
           let data,
@@ -255,7 +252,7 @@ export default Ember.Mixin.create({
             useRelated = !relationship.data;
 
           relationship.links = {
-            [useRelated ? 'related' : 'self']: extractLink(link)
+            [useRelated ? 'related' : 'self']: this.extractLink(link)
           };
         }
 


### PR DESCRIPTION
In later Ember (2.10+), the way `this._super` is called changed, causing
the calls to `keyForRelationship`, `keyForLink` and `extractLink` to
fail when called by the `extractRelationships` method.

This commit changes them to simply call `this.X` instead of peeling off
the function property from `this` and calling it later.